### PR TITLE
src/lib.rs: make verify public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,4 +268,4 @@ mod kx;
 mod misc;
 pub mod quic;
 pub mod sign;
-mod verify;
+pub mod verify;


### PR DESCRIPTION
In order to implement out-of-tree verifiers, we need access to the `verify` mod.